### PR TITLE
Mapped vim bindings (j/k) to prev/next and space to next

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -21,10 +21,12 @@ new Carousel('#slides');
         _this.slide_count = document.querySelectorAll("" + _this.selector + " > *").length;
         document.body.addEventListener('keydown', function(event) {
           var _ref, _ref1;
-          if ((_ref = event.keyCode) === 39 || _ref === 40) {
+          if ((_ref = event.keyCode) === 39 || _ref === 40 || _ref === 74 || _ref === 32) {
+            event.preventDefault();
             _this.next();
           }
-          if ((_ref1 = event.keyCode) === 37 || _ref1 === 38) {
+          if ((_ref1 = event.keyCode) === 37 || _ref1 === 38 || _ref1 === 75) {
+            event.preventDefault();
             return _this.prev();
           }
         });

--- a/index.coffee
+++ b/index.coffee
@@ -14,8 +14,14 @@ module.exports = class Carousel
       @slide_count = document.querySelectorAll("#{@selector} > *").length
 
       document.body.addEventListener 'keydown', (event) =>
-        @next() if event.keyCode in [39, 40] # right or down
-        @prev() if event.keyCode in [37, 38] # left or up
+        # right, down, j, or space
+        if event.keyCode in [39, 40, 74, 32]
+            event.preventDefault()
+            @next()
+        # left, up, or k
+        if event.keyCode in [37, 38, 75]
+            event.preventDefault()
+            @prev()
 
       @getOffset()
 

--- a/index.js
+++ b/index.js
@@ -14,10 +14,12 @@
         _this.slide_count = document.querySelectorAll("" + _this.selector + " > *").length;
         document.body.addEventListener('keydown', function(event) {
           var _ref, _ref1;
-          if ((_ref = event.keyCode) === 39 || _ref === 40) {
+          if ((_ref = event.keyCode) === 39 || _ref === 40 || _ref === 74 || _ref === 32) {
+            event.preventDefault();
             _this.next();
           }
-          if ((_ref1 = event.keyCode) === 37 || _ref1 === 38) {
+          if ((_ref1 = event.keyCode) === 37 || _ref1 === 38 || _ref1 === 75) {
+            event.preventDefault();
             return _this.prev();
           }
         });


### PR DESCRIPTION
- Mapped j/k down/up vim bindings to next/prev because muscle memory
- Mapped space to next because it's a large, easy-to-hit button, and
  it's default behavior is to go down anyway, which would throw off
  the alignment.
- Added `preventDefault` call on the event so that default up/down/space
  behavior wouldn't affect the alignment
